### PR TITLE
Fix incorrect import in widget test

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hsadmin/main.dart';
+import 'package:healthsphere_admin/main.dart';
 
 void main() {
   testWidgets('renders login screen on startup', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- fix broken import path in `widget_test.dart`

## Testing
- `flutter test test/widget_test.dart` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683f678c4f288320b3bfb8ff918c4cc2