### PR TITLE
Implement shared app theme

### DIFF
--- a/lib/admin/dashboard.dart
+++ b/lib/admin/dashboard.dart
@@ -52,6 +52,7 @@ class _AdminDashboardState extends State<AdminDashboard> {
   }
 
   Widget _statCard(String label, int count, IconData icon, Color color) {
+    final scheme = Theme.of(context).colorScheme;
     return Card(
       elevation: 3,
       margin: const EdgeInsets.all(8),
@@ -67,9 +68,9 @@ class _AdminDashboardState extends State<AdminDashboard> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            Icon(icon, size: 36, color: Colors.white),
-            Text(label, style: const TextStyle(color: Colors.white, fontSize: 16)),
-            Text('$count', style: const TextStyle(color: Colors.white, fontSize: 24, fontWeight: FontWeight.bold)),
+            Icon(icon, size: 36, color: scheme.onPrimary),
+            Text(label, style: TextStyle(color: scheme.onPrimary, fontSize: 16)),
+            Text('$count', style: TextStyle(color: scheme.onPrimary, fontSize: 24, fontWeight: FontWeight.bold)),
           ],
         ),
       ),
@@ -78,6 +79,7 @@ class _AdminDashboardState extends State<AdminDashboard> {
 
   @override
   Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
     return Scaffold(
       body: Row(
         children: [
@@ -85,9 +87,9 @@ class _AdminDashboardState extends State<AdminDashboard> {
           Expanded(
             child: Container(
               padding: const EdgeInsets.all(24),
-              decoration: const BoxDecoration(
+              decoration: BoxDecoration(
                 gradient: LinearGradient(
-                  colors: [Color(0xFFB6E0FE), Color(0xFF5B8CFF)],
+                  colors: [scheme.primaryContainer, scheme.primary],
                   begin: Alignment.topCenter,
                   end: Alignment.bottomCenter,
                 ),
@@ -98,10 +100,10 @@ class _AdminDashboardState extends State<AdminDashboard> {
                   AppBar(
                     backgroundColor: Colors.transparent,
                     elevation: 0,
-                    title: const Text('Admin Dashboard', style: TextStyle(color: Colors.white)),
+                    title: Text('Admin Dashboard', style: TextStyle(color: scheme.onPrimary)),
                     actions: [
                       IconButton(
-                        icon: const Icon(Icons.logout, color: Colors.white),
+                        icon: Icon(Icons.logout, color: scheme.onPrimary),
                         onPressed: () async {
                           await FirebaseAuth.instance.signOut();
                           if (mounted) {
@@ -116,11 +118,11 @@ class _AdminDashboardState extends State<AdminDashboard> {
                     spacing: 20,
                     runSpacing: 20,
                     children: [
-                      _statCard('Doctors', doctors, Icons.medical_services, Colors.indigo),
-                      _statCard('Patients', patients, Icons.people, Colors.teal),
-                      _statCard('Appointments', appointments, Icons.calendar_today, Colors.deepOrange),
-                      _statCard('Medicines', medicines, Icons.medication, Colors.purple),
-                      _statCard('Ambulances', ambulances, Icons.local_shipping, Colors.redAccent),
+                      _statCard('Doctors', doctors, Icons.medical_services, scheme.primary),
+                      _statCard('Patients', patients, Icons.people, scheme.secondary),
+                      _statCard('Appointments', appointments, Icons.calendar_today, scheme.tertiary),
+                      _statCard('Medicines', medicines, Icons.medication, scheme.primaryContainer),
+                      _statCard('Ambulances', ambulances, Icons.local_shipping, scheme.error),
                     ],
                   )
                 ],

--- a/lib/admin/login.dart
+++ b/lib/admin/login.dart
@@ -82,12 +82,13 @@ class _LoginPageState extends State<LoginPage> {
     return Scaffold(
       body: LayoutBuilder(
         builder: (context, constraints) {
+          final scheme = Theme.of(context).colorScheme;
           return Container(
             width: constraints.maxWidth,
             height: constraints.maxHeight,
-            decoration: const BoxDecoration(
+            decoration: BoxDecoration(
               gradient: LinearGradient(
-                colors: [Color(0xFF0072B5), Color(0xFF001F54)],
+                colors: [scheme.primary, scheme.primaryContainer],
                 begin: Alignment.topCenter,
                 end: Alignment.bottomCenter,
               ),
@@ -105,12 +106,12 @@ class _LoginPageState extends State<LoginPage> {
                               vertical: 10, horizontal: 20),
                           margin: const EdgeInsets.only(bottom: 16),
                           decoration: BoxDecoration(
-                            color: Colors.red[400],
+                            color: scheme.errorContainer,
                             borderRadius: BorderRadius.circular(12),
                           ),
                           child: Text(
                             _errorMessage!,
-                            style: const TextStyle(color: Colors.white),
+                            style: TextStyle(color: scheme.onErrorContainer),
                           ),
                         ),
                       Image.asset(
@@ -118,16 +119,16 @@ class _LoginPageState extends State<LoginPage> {
                         height: 100,
                       ),
                       const SizedBox(height: 12),
-                      const Text(
+                      Text(
                         'Administrator Login',
-                        style: TextStyle(color: Colors.white, fontSize: 14),
+                        style: TextStyle(color: scheme.onPrimary, fontSize: 14),
                       ),
                       const SizedBox(height: 24),
                       Container(
                         padding: const EdgeInsets.symmetric(
                             horizontal: 24, vertical: 28),
                         decoration: BoxDecoration(
-                          color: Colors.white,
+                          color: scheme.surface,
                           borderRadius: BorderRadius.circular(12),
                         ),
                         child: Column(
@@ -138,7 +139,7 @@ class _LoginPageState extends State<LoginPage> {
                               decoration: InputDecoration(
                                 hintText: 'Email',
                                 filled: true,
-                                fillColor: Colors.white,
+                                fillColor: scheme.surface,
                                 contentPadding: const EdgeInsets.symmetric(
                                     horizontal: 12, vertical: 12),
                                 border: OutlineInputBorder(
@@ -153,7 +154,7 @@ class _LoginPageState extends State<LoginPage> {
                               decoration: InputDecoration(
                                 hintText: 'Password',
                                 filled: true,
-                                fillColor: Colors.white,
+                                fillColor: scheme.surface,
                                 contentPadding: const EdgeInsets.symmetric(
                                     horizontal: 12, vertical: 12),
                                 border: OutlineInputBorder(
@@ -167,15 +168,16 @@ class _LoginPageState extends State<LoginPage> {
                               height: 45,
                               child: ElevatedButton(
                                 style: ElevatedButton.styleFrom(
-                                  backgroundColor: Colors.black,
+                                  backgroundColor: scheme.primary,
+                                  foregroundColor: scheme.onPrimary,
                                   shape: RoundedRectangleBorder(
                                     borderRadius: BorderRadius.circular(8),
                                   ),
                                 ),
                                 onPressed: _isLoading ? null : _login,
                                 child: _isLoading
-                                    ? const CircularProgressIndicator(
-                                  color: Colors.white,
+                                    ? CircularProgressIndicator(
+                                  color: scheme.onPrimary,
                                 )
                                     : const Text('Login In'),
                               ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'firebase_options.dart';
 import 'package:healthsphere_admin/admin/manage_ai_chats.dart';
+import 'theme/app_theme.dart';
 // Admin Pages
 import 'admin/login.dart';
 import 'admin/dashboard.dart';
@@ -41,10 +42,7 @@ class HealthSphereWebApp extends StatelessWidget {
     return MaterialApp(
       title: 'HealthSphere Admin',
       debugShowCheckedModeBanner: false,
-      theme: ThemeData(
-        primarySwatch: Colors.indigo,
-        useMaterial3: true,
-      ),
+      theme: AppTheme.lightTheme,
       home: const RoleRedirector(), // ⬅️ Handles auth + role check
       routes: {
         '/login': (context) => const LoginPage(),

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AppTheme {
+  static final ThemeData lightTheme = ThemeData(
+    colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+    useMaterial3: true,
+    textTheme: GoogleFonts.poppinsTextTheme(),
+  );
+}


### PR DESCRIPTION
## Summary
- create `AppTheme` with Poppins text theme and seeded `ColorScheme`
- apply `AppTheme.lightTheme` in `main.dart`
- replace hard-coded colors in login and dashboard pages

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f84619df88320a457a3472acc0292